### PR TITLE
[x86/Linux] fix TC 'b00722' fail.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2725,6 +2725,8 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
 
         // Jump to the excption-throwing block on error.
 
+        if (codeKind == SCK_OVERFLOW)
+            inst_RV_IV(INS_AND, REG_SPBASE, ~(STACK_ALIGN - 1), EA_PTRSIZE);
         inst_JMP(jumpKind, tgtBlk);
     }
     else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2725,8 +2725,6 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
 
         // Jump to the excption-throwing block on error.
 
-        if (codeKind == SCK_OVERFLOW)
-            inst_RV_IV(INS_AND, REG_SPBASE, ~(STACK_ALIGN - 1), EA_PTRSIZE);
         inst_JMP(jumpKind, tgtBlk);
     }
     else

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5153,6 +5153,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             {
                 fPossibleSyncHelperCall = true;
             }
+
+#if defined(UNIX_X86_ABI)
+            if (helperNum == CORINFO_HELP_OVERFLOW)
+                inst_RV_IV(INS_AND, REG_SPBASE, ~(STACK_ALIGN - 1), EA_PTRSIZE);
+#endif
         }
         else
         {


### PR DESCRIPTION
add emitting "and" instruction in genJumpToThrowHlpBlk().